### PR TITLE
Unlike the Tory party, allow foreign people in (aka fix panda encoding bug)

### DIFF
--- a/lib/pandaUtils.js
+++ b/lib/pandaUtils.js
@@ -66,7 +66,7 @@ Utils.stringToRSAPublicFormat = function (string) {
  */
 Utils.verifySignature = function (message, signature, pandaPublicKey) {
     return crypto.createVerify('sha256WithRSAEncryption')
-                    .update(message)
+                    .update(message, 'utf-8')
                     .verify(pandaPublicKey, signature, 'base64');
 };
 


### PR DESCRIPTION
Specify encoding when verifying panda sig to account for non-ASCII content, eg names. Otherwise the verification fails for "Sébastien", for example.

Tested in the Node REPL.