### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pan-domain-node",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "NodeJs implementation of Guardian pan-domain auth verification",
   "main": "lib/pandaAuth.js",
   "directories": {
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/guardian/pan-domain-node",
   "dependencies": {
-    "aws-sdk": "^2.1.40",
+    "aws-sdk": "^2.2.12",
     "colors": "^1.1.2",
     "q": "^1.4.1",
-    "qs": "^4.0.0"
+    "qs": "^5.2.0"
   },
   "devDependencies": {
     "jasmine-node": "^1.14.5"


### PR DESCRIPTION
`Qs` is a major version update, the breaking change is `allowDots`

in qs4:

```
Qs.parse('a.b=c', { allowDots: true });
//  {a: {b: 'c'}}
```

in qs5 by default
```
Qs.parse('a.b=c', { allowDots: true });
//  {'a.b': 'c'}
```

I don't think we use dots in our cookies, so this should be a safe update. I've also promoted `0.0.1` to `0.1.0`