### PR TITLE
override default logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,17 @@ app.use(function(err, req, res, next) {
     };
 });
 ```
+
+## Logging
+
+By default `pan-domain-node` logs to `console`. You can configure a custom logger
+
+```js
+function customLogger (level, message) {
+	// level is either 'error',  'info', 'debug'
+}
+
+PanDomainNode.setLogger(customLogger);
+```
+
+This allow for instance to send logs to [winston](https://github.com/winstonjs/winston) or [bunyan](https://github.com/trentm/node-bunyan).

--- a/lib/pandaAuth.js
+++ b/lib/pandaAuth.js
@@ -67,6 +67,7 @@ module.exports = function (domain) {
     return {
         Middleware: new PandaAuthVerify(),
         setLogLevel: PandaUtils.setLogLevel,
+        setLogger: PandaUtils.setLogger,
         PandaAuthFailedErrorMessage: PandaUtils.AUTH_FAILED_ERROR_MESSAGE
     };
 };

--- a/lib/pandaUtils.js
+++ b/lib/pandaUtils.js
@@ -11,6 +11,7 @@ var Utils = {
     
     }
 };
+var overriddenLogger;
 
 Utils.decodeBase64 = function (data) {
     return (new Buffer(data, 'base64')).toString('utf8')
@@ -70,6 +71,10 @@ Utils.verifySignature = function (message, signature, pandaPublicKey) {
                     .verify(pandaPublicKey, signature, 'base64');
 };
 
+Utils.setLogger = function (logger) {
+    overriddenLogger = logger;
+};
+
 Utils.setLogLevel = function (requestedLogLevel) {
     if (Utils.logLevels.indexOf(requestedLogLevel) !== -1) {
         Utils.logLevel = requestedLogLevel;
@@ -87,14 +92,18 @@ Utils.log = function (level, message) {
     }
 
     if (Utils.logLevels.indexOf(level) <= Utils.logLevels.indexOf(Utils.logLevel)) {
-        Array.isArray(message) ? console[level].apply(null, message) : console[level](message[cols[level]]);
+        if (overriddenLogger) {
+            overriddenLogger(level, message);
+        } else {
+            Array.isArray(message) ? console[level].apply(null, message) : console[level](message[cols[level]]);
+        }
     }
 };
 
 Utils.setAwsBucket = function (domain) {
     if (domain) {
         Utils.log('info', 'setting domain ' + domain);
-        Utils.settings.pandaPublicKey =  domain + ".settings.public",
+        Utils.settings.pandaPublicKey =  domain + '.settings.public',
         Utils.settings.pandaBucket = 'pan-domain-auth-settings'
     } else {
         Utils.log('error', 'Please provide an S3 target domain and key for the AWS key download');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pan-domain-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "NodeJs implementation of Guardian pan-domain auth verification",
   "main": "lib/pandaAuth.js",
   "directories": {
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/guardian/pan-domain-node",
   "dependencies": {
-    "aws-sdk": "^2.2.12",
+    "aws-sdk": "^2.2.15",
     "colors": "^1.1.2",
     "q": "^1.4.1",
     "qs": "^5.2.0"


### PR DESCRIPTION
This allows to use the same logger used by the containing application. An example is `switchboard` using `winston` to log to file (and to kinesis in the future).


```js
PanDomainNode.setLogger(winston.log.bind(winston))
```

@chrisfinch 