### PR TITLE
Update code owner to workflow-and-collaboration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/digital-cms
+* @guardian/workflow-and-collaboration


### PR DESCRIPTION
The [Workflow and Collaboration team](https://github.com/orgs/guardian/teams/workflow-and-collaboration) are [taking ownership of panda](https://github.com/guardian/pan-domain-authentication/pull/189), and we feel it makes sense for us to also take ownership of this repository as it is so closely related. This PR therefore sets the code owner for this repository to be us.

To test:

- confirm that github flags the code owners file as valid
- after merge, test that opening a PR causes a code owners review request from workflow and collaboration