### PR TITLE
Add a grace period modelled with `shouldRefreshCredentials`

### DIFF
--- a/.changeset/moody-buckets-rush.md
+++ b/.changeset/moody-buckets-rush.md
@@ -1,0 +1,97 @@
+---
+"@guardian/pan-domain-node": major
+---
+
+# Changes
+Adds a 24-hour grace period after cookie expiry, during which requests will still be considered authenticated.
+
+This is modelled by changing `AuthenticatedStatus` into a discriminated union with the following properties (among others):
+
+### `success`
+Whether to treat request as authenticated or not. **This will remain true after cookie expiry for the length of the grace period.**
+
+[Almost all consumers](https://docs.google.com/spreadsheets/d/19XABaP9ua935TYJARkL8tstnizL69gIJ9av8C3UQBYw/edit?gid=0#gid=0) of this library check **only** the `AUTHORISED` status right now. These should all be able to switch to checking just this single boolean, implicitly getting grace period functionality in the process.
+
+### `shouldRefreshCredentials`
+Whether to try and get fresh credentials.
+
+This allows page endpoints to redirect to auth, and API endpoints to tell the frontend to show a warning message to the user.
+
+### `mustRefreshByEpochTimeMillis`
+The time at which the grace period ends and the request will be treated as unauthenticated. This allows library consumers to warn the user in the app UI when they are near the end of the grace period, as Composer does: https://github.com/guardian/flexible-content/pull/5210
+
+```
+Panda cookie:               issued     expires                       `mustRefreshByEpochTimeMillis`
+                            |          |                             |
+                            |--1 hour--|                             |
+Grace period:                          [------------- 24 hours ------]
+
+`success`:         --false-][-true-----------------------------------][-false-------->
+`shouldRefreshCredentials`  [-false---][-true------------------------]
+```
+
+# Why have we made this change?
+The Panda authentication cookie expires after 1 hour, and top-level navigation requests (page loads) trigger automatic re-authentication after this point.
+
+Unfortunately API requests cannot trigger re-authentication on their own, and background refresh mechanisms (e.g. iframe-based method used by [Pandular](https://github.com/guardian/pandular)) are increasingly blocked by browsers due to third-party cookie restrictions.
+
+We would like to enforce a 24-hour grace period
+
+# How to update consuming code
+At a minimum, switch from
+
+```typescript
+const authResult = await panda.verify(cookieHeader);
+if (authResult.status === AuthenticationStatus.AUTHORISED && authResult.user) {
+    return authResult.user.email;
+}
+```
+
+to
+
+```typescript
+const authResult = await panda.verify(cookieHeader);
+if (authResult.success) {
+    return authResult.user.email;
+}
+```
+
+This will implicitly give you grace period functionality, because `success` will remain true during the grace period.
+
+However, we **strongly** recommend all consumers to take account of `shouldRefreshCredentials`. What you do with the result should depend on whether your endpoint can trigger re-auth.
+
+## Endpoints that can refresh credentials
+Endpoints that **can** refresh credentials, e.g. page endpoints that can redirect to an auth flow, should send the user to re-auth if `shouldRefreshCredentials` is `true`:
+```typescript
+const authResult = await panda.verify(headers.cookie);
+if (authResult.success) {
+    if (authResult.shouldRefreshCredentials) {
+        // Send for auth
+    } else {
+        // Can perform action with user
+        return authResult.user;
+    }
+}
+```
+
+## Endpoints that cannot refresh credentials
+Endpoints that **cannot** refresh credentials, e.g. API endpoints, should log appropriately and return something to the client that can be used to warn the user that they need to refresh their session. 
+
+```typescript
+const authResult = await panda.verify(headers.cookie);
+if (authResult.success) {
+  const user = authResult.user;
+  // Handle request
+  // When returning response:
+  if (authResult.shouldRefreshCredentials) {
+    const mustRefreshByEpochTimeMillis = authResult.mustRefreshByEpochTimeMillis;
+    const remainingTime = mustRefreshByEpochTimeMillis - Date.now();
+    console.warn(`Stale Panda auth, will expire in ${remainingTime} milliseconds`);
+    // Can still return 200, but depending on the type of API,
+    // we may want to return some extra information so the client
+    // can warn the user they need to refresh their session.
+   } else {
+    // It's a fresh session. Nothing to worry about!
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/pan-domain-node",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/pan-domain-node",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cookie": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pan-domain-node",
-  "version": "1.0.0",
+  "version": "0.5.1",
   "description": "NodeJs implementation of Guardian pan-domain auth verification",
   "main": "dist/src/api.js",
   "types": "dist/src/api.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/pan-domain-node",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "description": "NodeJs implementation of Guardian pan-domain auth verification",
   "main": "dist/src/api.js",
   "types": "dist/src/api.d.ts",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,23 +1,23 @@
 export { PanDomainAuthentication } from './panda';
 
-export type AuthenticatedResult = {
+export type Authenticated = {
     success: true,
-    suggestCredentialsRefresh: boolean,
+    shouldRefreshCredentials: boolean,
     user: User
 }
-export type UnauthenticatedResult = {
+export type Unauthenticated = {
     success: false,
-    reason: 'no-cookie' | 'bad-cookie' | 'expired-cookie' | 'bad-user' | 'unknown'
+    reason: 'no-cookie' | 'bad-cookie' | 'expired-cookie' | 'unknown'
 }
-export type UnauthorisedResult = {
+export type Unauthorised = {
     success: false,
     reason: 'bad-user',
     user: User
 }
 
-export type AuthenticationResult = AuthenticatedResult
-    | UnauthenticatedResult
-    | UnauthorisedResult
+export type AuthenticationResult = Authenticated
+    | Unauthenticated
+    | Unauthorised
 
 export interface User {
     firstName: string,
@@ -29,6 +29,8 @@ export interface User {
     expires: number,
     multifactor: boolean
 }
+
+export const gracePeriodInMillis = 24 * 60 * 60 * 1000;
 
 export type ValidateUserFn = (user: User) => boolean;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -16,16 +16,15 @@ export const gracePeriodInMillis = 24 * 60 * 60 * 1000;
 
 export type FreshlyAuthenticated = {
     success: true,
-    // Our cookie hasn't yet expired, so this is false
+    // Cookie has not expired yet, so no need to refresh credentials.
     shouldRefreshCredentials: false,
     user: User
 }
 export type Authenticated = {
     success: true,
-    // `shouldRefreshCredentials: true` because the user is in the grace period.
-    // It indicates that:
-    // - page endpoints that *can* refresh credentials should do so
-    // - API endpoints that *cannot* refresh credentials should tell the user to do so
+    // Cookie has expired: we're in the grace period.
+    // So indicate that endpoints that can refresh credentials should do so,
+    // and those that cannot should tell the user to do so.
     shouldRefreshCredentials: true,
     mustRefreshByEpochTimeMillis: number,
     user: User

--- a/src/api.ts
+++ b/src/api.ts
@@ -48,11 +48,11 @@ export interface StaleSuccess extends Success {
     mustRefreshByEpochTimeMillis: number
 }
 export interface UserValidationFailure extends Failure {
-    reason: 'bad-user',
+    reason: 'invalid-user',
     user: User
 }
 export interface CookieFailure extends Failure {
-    reason: 'no-cookie' | 'bad-cookie' | 'expired-cookie'
+    reason: 'no-cookie' | 'invalid-cookie' | 'expired-cookie'
 }
 export interface UnknownFailure extends Failure {
     reason: 'unknown'

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,11 +1,23 @@
 export { PanDomainAuthentication } from './panda';
 
-export enum AuthenticationStatus {
-    INVALID_COOKIE = 'Invalid Cookie',
-    EXPIRED = 'Expired',
-    NOT_AUTHORISED = 'Not Authorised',
-    AUTHORISED = 'Authorised'
+export type AuthenticatedResult = {
+    success: true,
+    suggestCredentialsRefresh: boolean,
+    user: User
 }
+export type UnauthenticatedResult = {
+    success: false,
+    reason: 'no-cookie' | 'bad-cookie' | 'expired-cookie' | 'bad-user' | 'unknown'
+}
+export type UnauthorisedResult = {
+    success: false,
+    reason: 'bad-user',
+    user: User
+}
+
+export type AuthenticationResult = AuthenticatedResult
+    | UnauthenticatedResult
+    | UnauthorisedResult
 
 export interface User {
     firstName: string,
@@ -16,11 +28,6 @@ export interface User {
     authenticatedIn: string[],
     expires: number,
     multifactor: boolean
-}
-
-export interface AuthenticationResult {
-    status: AuthenticationStatus,
-    user?: User 
 }
 
 export type ValidateUserFn = (user: User) => boolean;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,24 @@
 export { PanDomainAuthentication } from './panda';
 
+// We continue to consider the request authenticated for
+// a period of time after the cookie expiry. This is to allow
+// API requests which cannot directly send the user for re-auth to
+// indicate to the user that they must take some action to refresh their
+// credentials (usually, refreshing the page).
+
+// Panda cookie:               issued     expires
+//                             |          |
+//                             |--1 hour--|
+// Grace period:                          [------------- 24 hours ------]
+// `success`:         --false-][-true-----------------------------------][-false-------->
+// `shouldRefreshCredentials`  [-false---][-true------------------------]
+export const gracePeriodInMillis = 24 * 60 * 60 * 1000;
+
 export type Authenticated = {
     success: true,
+    // This will be true if the user is in the grace period. It indicates that:
+    // - page endpoints that *can* refresh credentials should do so
+    // - API endpoints that *cannot* refresh credentials should tell the user to do so
     shouldRefreshCredentials: boolean,
     user: User
 }
@@ -29,8 +46,6 @@ export interface User {
     expires: number,
     multifactor: boolean
 }
-
-export const gracePeriodInMillis = 24 * 60 * 60 * 1000;
 
 export type ValidateUserFn = (user: User) => boolean;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,7 +23,7 @@ export type FreshlyAuthenticated = {
 export type Authenticated = {
     success: true,
     // Cookie has expired: we're in the grace period.
-    // So indicate that endpoints that can refresh credentials should do so,
+    // Endpoints that can refresh credentials should do so,
     // and those that cannot should tell the user to do so.
     shouldRefreshCredentials: true,
     mustRefreshByEpochTimeMillis: number,

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,12 +14,20 @@ export { PanDomainAuthentication } from './panda';
 // `shouldRefreshCredentials`  [-false---][-true------------------------]
 export const gracePeriodInMillis = 24 * 60 * 60 * 1000;
 
+export type FreshlyAuthenticated = {
+    success: true,
+    // Our cookie hasn't yet expired, so this is false
+    shouldRefreshCredentials: false,
+    user: User
+}
 export type Authenticated = {
     success: true,
-    // This will be true if the user is in the grace period. It indicates that:
+    // `shouldRefreshCredentials: true` because the user is in the grace period.
+    // It indicates that:
     // - page endpoints that *can* refresh credentials should do so
     // - API endpoints that *cannot* refresh credentials should tell the user to do so
-    shouldRefreshCredentials: boolean,
+    shouldRefreshCredentials: true,
+    mustRefreshByEpochTimeMillis: number,
     user: User
 }
 export type Unauthenticated = {
@@ -32,7 +40,8 @@ export type Unauthorised = {
     user: User
 }
 
-export type AuthenticationResult = Authenticated
+export type AuthenticationResult = FreshlyAuthenticated
+    | Authenticated
     | Unauthenticated
     | Unauthorised
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -22,8 +22,9 @@ interface Result {
 }
 interface Success extends Result {
     // `success` is true when both these are true:
-    // - we've verified that the cookie is signed by the correct private key and decoded a `User` from it
-    // - we've validated the `User` using `ValidateUserFn`
+    // 1. we've verified that the cookie is signed by the correct private key
+    //    and decoded a `User` from it
+    // 2. we've validated the `User` using `ValidateUserFn`
     success: true,
     shouldRefreshCredentials: boolean,
     user: User

--- a/src/panda.ts
+++ b/src/panda.ts
@@ -32,7 +32,14 @@ export function verifyUser(pandaCookie: string | undefined, publicKey: string, c
         };
     }
 
-    const { data, signature } = parseCookie(pandaCookie);
+    const parsedCookie = parseCookie(pandaCookie);
+    if (!parsedCookie) {
+        return {
+            success: false,
+            reason: 'bad-cookie'
+        };
+    }
+    const { data, signature } = parsedCookie;
 
     if (!verifySignature(data, signature, publicKey)) {
         return {

--- a/src/panda.ts
+++ b/src/panda.ts
@@ -36,7 +36,7 @@ export function verifyUser(pandaCookie: string | undefined, publicKey: string, c
     if (!parsedCookie) {
         return {
             success: false,
-            reason: 'bad-cookie'
+            reason: 'invalid-cookie'
         };
     }
     const { data, signature } = parsedCookie;
@@ -44,7 +44,7 @@ export function verifyUser(pandaCookie: string | undefined, publicKey: string, c
     if (!verifySignature(data, signature, publicKey)) {
         return {
             success: false,
-            reason: 'bad-cookie'
+            reason: 'invalid-cookie'
         };
     }
 
@@ -74,7 +74,7 @@ export function verifyUser(pandaCookie: string | undefined, publicKey: string, c
         if (!validateUser(user)) {
             return {
                 success: false,
-                reason: 'bad-user',
+                reason: 'invalid-user',
                 user
             };
         }

--- a/src/panda.ts
+++ b/src/panda.ts
@@ -101,7 +101,7 @@ export class PanDomainAuthentication {
     validateUser: ValidateUserFn;
 
     publicKey: Promise<PublicKeyHolder>;
-    keyCacheTime: number = 60 * 1000; // 1 minute
+    keyCacheTimeInMillis: number = 60 * 1000; // 1 minute
     keyUpdateTimer?: NodeJS.Timeout;
 
     constructor(cookieName: string, region: string, bucket: string, keyFile: string, validateUser: ValidateUserFn) {
@@ -113,7 +113,7 @@ export class PanDomainAuthentication {
 
         this.publicKey = fetchPublicKey(region, bucket, keyFile);
 
-        this.keyUpdateTimer = setInterval(() => this.getPublicKey(), this.keyCacheTime);
+        this.keyUpdateTimer = setInterval(() => this.getPublicKey(), this.keyCacheTimeInMillis);
     }
 
     stop(): void {
@@ -128,7 +128,7 @@ export class PanDomainAuthentication {
             const now = new Date();
             const diff = now.getTime() - lastUpdated.getTime();
 
-            if(diff > this.keyCacheTime) {
+            if(diff > this.keyCacheTimeInMillis) {
                 this.publicKey = fetchPublicKey(this.region, this.bucket, this.keyFile);
                 return this.publicKey.then(({ key }) => key);
             } else {

--- a/src/panda.ts
+++ b/src/panda.ts
@@ -48,15 +48,15 @@ export function verifyUser(pandaCookie: string | undefined, publicKey: string, c
         };
     }
 
-    const currentTimestampInMilliseconds = currentTime.getTime();
+    const currentTimestampInMillis = currentTime.getTime();
 
     try {
         const user: User = parseUser(data);
-        const isExpired = user.expires < currentTimestampInMilliseconds;
+        const isExpired = user.expires < currentTimestampInMillis;
 
         if (isExpired) {
-            const twentyFourHoursAgo = currentTimestampInMilliseconds - gracePeriodInMillis;
-            if (user.expires < twentyFourHoursAgo) {
+            const gracePeriodEndsAtEpochTimeMillis = user.expires + gracePeriodInMillis;
+            if (gracePeriodEndsAtEpochTimeMillis < currentTimestampInMillis) {
                 return {
                     success: false,
                     reason: 'expired-cookie'
@@ -65,6 +65,7 @@ export function verifyUser(pandaCookie: string | undefined, publicKey: string, c
                 return {
                     success: true,
                     shouldRefreshCredentials: true,
+                    mustRefreshByEpochTimeMillis: gracePeriodEndsAtEpochTimeMillis,
                     user
                 }
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,17 +9,39 @@ export function decodeBase64(data: string): string {
 }
 
 export type ParsedCookie = { data: string, signature: string };
+
+/**
+ * Check if a string is valid base64
+ */
+function isBase64(str: string): boolean {
+    try {
+        return Buffer.from(str, 'base64').toString('base64') === str;
+    } catch (err) {
+        return false;
+    }
+}
+
 /**
  * Parse a pan-domain user cookie in to data and signature
+ * Validates that the cookie is properly formatted (two base64 strings separated by '.')
  */
 export function parseCookie(cookie: string): ParsedCookie | undefined {
-    const splitCookie = cookie.split('\.');
-    if (splitCookie.length !== 2) {
+    const cookieRegex = /^([\w\W]*)\.([\w\W]*)$/;
+    const match = cookie.match(cookieRegex);
+    
+    if (!match) {
         return undefined;
     }
+
+    const [, data, signature] = match;
+    
+    if (!isBase64(data) || !isBase64(signature)) {
+        return undefined;
+    }
+
     return {
-        data: decodeBase64(splitCookie[0]),
-        signature: splitCookie[1]
+        data: decodeBase64(data),
+        signature: signature
     };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,11 +8,15 @@ export function decodeBase64(data: string): string {
     return Buffer.from(data, 'base64').toString('utf8');
 }
 
+export type ParsedCookie = { data: string, signature: string };
 /**
  * Parse a pan-domain user cookie in to data and signature
  */
-export function parseCookie(cookie: string): { data: string, signature: string} {
+export function parseCookie(cookie: string): ParsedCookie | undefined {
     const splitCookie = cookie.split('\.');
+    if (splitCookie.length !== 2) {
+        return undefined;
+    }
     return {
         data: decodeBase64(splitCookie[0]),
         signature: splitCookie[1]

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -215,7 +215,7 @@ describe('panda class', function () {
       });
     });
 
-    it('authenticate with shouldRefreshCredentials if we\'re within the grace period', async () => {
+    it('authenticate with shouldRefreshCredentials if cookie expired but we\'re within the grace period', async () => {
       // Cookie expiry is 1234
       const beforeEndOfGracePeriodEpochMillis = 1234 + gracePeriodInMillis - 1;
       jest.setSystemTime(beforeEndOfGracePeriodEpochMillis);

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -85,9 +85,7 @@ describe('verifyUser', function () {
         const slightlyBadCookie = sampleCookie.slice(0, -2);
         expect(verifyUser(slightlyBadCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
     });
-
-    // TODO: Missing or malformed user data
-
+    
     test("authenticate if the cookie and user are valid", () => {
         expect(verifyUser(sampleCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual({
             success: true,

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -34,9 +34,10 @@ describe('verifyUser', function () {
     });
 
     test("fail to authenticate if cookie is expired", () => {
-        const someTimeInTheFuture = new Date(5678);
-        expect(someTimeInTheFuture.getTime()).toBe(5678);
-        expect(verifyUser(sampleCookie, publicKey, someTimeInTheFuture, guardianValidation)).toStrictEqual({
+        // Cookie expires at epoch time 1234
+        const oneSecondAfterCookieExpiry = new Date(1234 + 1000);
+        expect(oneSecondAfterCookieExpiry.getTime()).toBe(2234);
+        expect(verifyUser(sampleCookie, publicKey, oneSecondAfterCookieExpiry, guardianValidation)).toStrictEqual({
             success: false,
             reason: 'expired-cookie'
         });

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -72,14 +72,6 @@ describe('verifyUser', function () {
         });
     });
 
-    test("fail to authenticate with invalid-cookie reason if cookie is malformed", () => {
-        const expected: CookieFailure = {
-            success: false,
-            reason: 'invalid-cookie'
-        };
-        expect(verifyUser("complete garbage", publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
-    });
-
     test("fail to authenticate with invalid-cookie reason if signature is not valid", () => {
         const expected: CookieFailure = {
             success: false,
@@ -87,6 +79,46 @@ describe('verifyUser', function () {
         };
         const slightlyBadCookie = sampleCookie.slice(0, -2);
         expect(verifyUser(slightlyBadCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
+    });
+
+    test("fail to authenticate with invalid-cookie reason if data part is not base64", () => {
+        const expected: CookieFailure = {
+            success: false,
+            reason: 'invalid-cookie'
+        };
+        const [_, signature] = sampleCookie.split(".");
+        const nonBase64Data = "not-base64-data";
+        const testCookie = `${nonBase64Data}.${signature}`;
+        expect(verifyUser(testCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
+    });
+
+    test("fail to authenticate with invalid-cookie reason if signature part is not base64", () => {
+        const expected: CookieFailure = {
+            success: false,
+            reason: 'invalid-cookie'
+        };
+        const [data, _] = sampleCookie.split(".");
+        const nonBase64Signature = "not-base64-signature";
+        const testCookie = `${data}.${nonBase64Signature}`;
+        expect(verifyUser(testCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
+    });
+
+    test("fail to authenticate with invalid-cookie reason if cookie has no dot separator", () => {
+        const expected: CookieFailure = {
+            success: false,
+            reason: 'invalid-cookie'
+        };
+        const noDotCookie = sampleCookie.replace(".", "");
+        expect(verifyUser(noDotCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
+    });
+
+    test("fail to authenticate with invalid-cookie reason if cookie has multiple dot separators", () => {
+        const expected: CookieFailure = {
+            success: false,
+            reason: 'invalid-cookie'
+        };
+        const multipleDotsCookie = sampleCookie.replace(".", "..");
+        expect(verifyUser(multipleDotsCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
     });
 
     test("authenticate if the cookie and user are valid", () => {

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -44,7 +44,7 @@ describe('verifyUser', function () {
 
         const expected: CookieFailure = {
             success: false,
-            reason: 'bad-cookie'
+            reason: 'invalid-cookie'
         };
         expect(verifyUser(testCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
     });
@@ -62,28 +62,28 @@ describe('verifyUser', function () {
     test("fail to authenticate if user fails validation function", () => {
         expect(verifyUser(sampleCookieWithoutMultifactor, publicKey, new Date(0), guardianValidation)).toStrictEqual({
             success: false,
-            reason: 'bad-user',
+            reason: 'invalid-user',
             user: userFromCookie(sampleCookieWithoutMultifactor)
         });
         expect(verifyUser(sampleNonGuardianCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual({
             success: false,
-            reason: 'bad-user',
+            reason: 'invalid-user',
             user: userFromCookie(sampleNonGuardianCookie)
         });
     });
 
-    test("fail to authenticate with bad-cookie reason if cookie is malformed", () => {
+    test("fail to authenticate with invalid-cookie reason if cookie is malformed", () => {
         const expected: CookieFailure = {
             success: false,
-            reason: 'bad-cookie'
+            reason: 'invalid-cookie'
         };
         expect(verifyUser("complete garbage", publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
     });
 
-    test("fail to authenticate with bad-cookie reason if signature is not valid", () => {
+    test("fail to authenticate with invalid-cookie reason if signature is not valid", () => {
         const expected: CookieFailure = {
             success: false,
-            reason: 'bad-cookie'
+            reason: 'invalid-cookie'
         };
         const slightlyBadCookie = sampleCookie.slice(0, -2);
         expect(verifyUser(slightlyBadCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
@@ -258,7 +258,7 @@ describe('panda class', function () {
 
       const expected: UserValidationFailure = {
           success: false,
-          reason: 'bad-user',
+          reason: 'invalid-user',
           user: userFromCookie(sampleNonGuardianCookie)
       };
       expect(authenticationResult).toStrictEqual(expected);
@@ -304,7 +304,7 @@ describe('panda class', function () {
       expect(authenticationResult).toStrictEqual(expected);
     });
 
-    it('should fail to authenticate with bad-cookie reason if cookie is malformed', async () => {
+    it('should fail to authenticate with invalid-cookie reason if cookie is malformed', async () => {
       jest.setSystemTime(100);
 
       const panda = new PanDomainAuthentication('rightcookiename', 'region', 'bucket', 'keyfile', guardianValidation);
@@ -313,7 +313,7 @@ describe('panda class', function () {
 
       const expected: CookieFailure = {
         success: false,
-        reason: "bad-cookie"
+        reason: "invalid-cookie"
       };
       expect(authenticationResult).toStrictEqual(expected);
     });

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -71,7 +71,6 @@ describe('verifyUser', function () {
         });
     });
 
-    // Malformed cookie text (no dot)
     test("fail to authenticate with bad-cookie reason if cookie is malformed", () => {
         const expected: Unauthenticated = {
             success: false,
@@ -80,7 +79,6 @@ describe('verifyUser', function () {
         expect(verifyUser("complete garbage", publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
     });
 
-    // Signature not valid
     test("fail to authenticate with bad-cookie reason if signature is not valid", () => {
         const expected: Unauthenticated = {
             success: false,

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -22,6 +22,10 @@ jest.mock('../src/fetch-public-key');
 jest.useFakeTimers('modern');
 
 function userFromCookie(cookie: string): User {
+    // This function is only used to generate a `User` object from
+    // a well-formed text fixture cookie, in order to check that successful
+    // `AuthenticationResult`s have the right shape. As such we don't want
+    // to have to deal with the case of a bad cookie so we just cast to `ParsedCookie`.
     const parsedCookie = parseCookie(cookie) as ParsedCookie;
     return parseUser(parsedCookie.data);
 }
@@ -85,7 +89,7 @@ describe('verifyUser', function () {
         const slightlyBadCookie = sampleCookie.slice(0, -2);
         expect(verifyUser(slightlyBadCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual(expected);
     });
-    
+
     test("authenticate if the cookie and user are valid", () => {
         expect(verifyUser(sampleCookie, publicKey, new Date(0), guardianValidation)).toStrictEqual({
             success: true,

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -102,7 +102,8 @@ describe('verifyUser', function () {
         const expected: Authenticated = {
             success: true,
             user: userFromCookie(sampleCookie),
-            shouldRefreshCredentials: true
+            shouldRefreshCredentials: true,
+            mustRefreshByEpochTimeMillis: 1234 + gracePeriodInMillis
         }
         expect(verifyUser(sampleCookie, publicKey, beforeEndOfGracePeriod, guardianValidation)).toStrictEqual(expected);
     });
@@ -222,11 +223,13 @@ describe('panda class', function () {
       const panda = new PanDomainAuthentication('cookiename', 'region', 'bucket', 'keyfile', (u)=> true);
       const authenticationResult = await panda.verify(`cookiename=${sampleCookie}`);
 
-      expect(authenticationResult).toStrictEqual({
+      const expected: Authenticated = {
           success: true,
           shouldRefreshCredentials: true,
+          mustRefreshByEpochTimeMillis: 1234 + gracePeriodInMillis,
           user: userFromCookie(sampleCookie)
-      });
+      }
+      expect(authenticationResult).toStrictEqual(expected);
     });
 
     it('should fail to authenticate if user is not valid', async () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,11 +3,17 @@ import { sampleCookie } from './fixtures';
 import { URLSearchParams } from 'url';
 
 test("decode a cookie", () => {
-    const { data, signature } = parseCookie(sampleCookie);
-    expect(signature.length).toBe(684);
+    const parsedCookie = parseCookie(sampleCookie);
+    expect(parsedCookie).toBeDefined()
 
-    const params = new URLSearchParams(data);
-    
-    expect(params.get("firstName")).toBe("Test");
-    expect(params.get("lastName")).toBe("User");
+    // Unfortunately the above expect() doesn't narrow the type
+    if (parsedCookie) {
+        const { data, signature } = parsedCookie;
+        expect(signature.length).toBe(684);
+
+        const params = new URLSearchParams(data);
+
+        expect(params.get("firstName")).toBe("Test");
+        expect(params.get("lastName")).toBe("User");
+    }
 });


### PR DESCRIPTION
## Goals
For reasons described in https://github.com/guardian/pan-domain-authentication/pull/185 and [this doc](https://docs.google.com/document/d/1Rn76R5TgjYDpJ_1C4TrBYCWqYWhk0o3I-vS_rpamdnQ/edit?tab=t.0#heading=h.sfwn5i51mpsl), we would like to enforce a 24 hour grace period across all Panda apps.

We would also like the panda library API to encourage consumers to refresh credentials when the user is within the grace period. This means either sending for auth directly (page endpoints) or asking the user to take action to re-auth (API endpoints).

## Changes
With these goals in mind, this PR changes the `AuthenticationStatus` into a discriminated union with the following properties, among others:

### `success`
Whether to treat request as authenticated or not. **This will remain true after cookie expiry for the length of the grace period.**

[Almost all consumers](https://docs.google.com/spreadsheets/d/19XABaP9ua935TYJARkL8tstnizL69gIJ9av8C3UQBYw/edit?gid=0#gid=0) of this library check **only** the `AUTHORISED` status right now. These should all be able to switch to checking just this single boolean, implicitly getting grace period functionality in the process.

### `shouldRefreshCredentials`
Whether to try and get fresh credentials.

This allows page endpoints to redirect to auth, and API endpoints to tell the frontend to show a warning message to the user.

### `mustRefreshByEpochTimeMillis`
The time at which the grace period ends and the request will be treated as unauthenticated. This allows library consumers to warn the user in the app UI when they are near the end of the grace period, as Composer does: https://github.com/guardian/flexible-content/pull/5210

### Example usage
The discriminated union should make it easy to use in the intended way, e.g. for an API endpoint

```typescript
const authenticationResult = await panda.verify(headers.cookie);
if (authenticationResult.success) {
  const user = authenticationResult.user;
  // Handle request
  // When returning response:
  if (authenticationResult.shouldRefreshCredentials) {
    const mustRefreshByEpochTimeMillis = authenticationResult.mustRefreshByEpochTimeMillis;
    // Can still return 200, but may want to return some extra information
    // so the client can warn the user they need to refresh their session
   } else {
    // It's a fresh session. Nothing to worry about!
  }
}
```
or a page endpoint:

```typescript
const authenticationResult = await panda.verify(headers.cookie);
if (authenticationResult.success) {
  if (authenticationResult.shouldRefreshCredentials) {
    // Send for auth
  } else {
    // Can perform action with user
    return authenticationResult.user;
  }
}
```

### Timeline
Here's how the above properties map onto the auth lifecycle timeline:
```
Panda cookie:               issued     expires                       `mustRefreshByEpochTimeMillis`
                            |          |                             |
                            |--1 hour--|                             |
Grace period:                          [------------- 24 hours ------]

`success`:         --false-][-true-----------------------------------][-false-------->
`shouldRefreshCredentials`  [-false---][-true------------------------]
```

@guardian/digital-cms 