### PR TITLE
Add canary release action

### DIFF
--- a/.github/actions/setup-node-and-npm-for-publishing/action.yml
+++ b/.github/actions/setup-node-and-npm-for-publishing/action.yml
@@ -1,0 +1,17 @@
+name: "Setup Environment"
+description: "Sets up Node.js environment and installs dependencies"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version-file: ".nvmrc"
+        cache: npm
+        cache-dependency-path: "package-lock.json"
+
+    # See https://docs.npmjs.com/trusted-publishers
+    # Find the latest version with `npm info npm@latest version`
+    - name: Install suitable NPM version for trusted publishing
+      run: npm install -g npm@11.10.1
+      shell: bash

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -1,31 +1,96 @@
-name: CD
+name: Publish to npm
+
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  # Trigger on a label being added to a PR, and publish a canary versions of all packages with waiting changesets to npm.
+  # Use `make changeset` to add a new changeset.
+  pull_request:
+    types: [labeled, synchronize]
+  # Trigger for standard (changesets) release after CI on main
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
 
 jobs:
-  CD:
+  release-canaries:
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, '🐥 Canaries') }}
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # This makes Actions fetch all Git history so that Changesets can
+          # generate changelogs with the correct commits
+          fetch-depth: 0
 
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+      - uses: ./.github/actions/setup-node-and-npm-for-publishing
+
+      - name: Version
+        run: npx changeset version --snapshot canary
+
+      # after the versioning the new versions need to be reflected in the lockfile.
+      # https://github.com/changesets/changesets/issues/421
+      - run: npm install --package-lock-only
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+      - name: Release
+        uses: changesets/action@v1
+        id: publish-canary
+        with:
+          # currently, you have to tag releases in git to get the action output to appear
+          # https://github.com/changesets/action/issues/141
+          # publish: npx changeset publish --no-git-tag --tag canary
+          publish: npx changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/github-script@v8
+        if: steps.publish-canary.outputs.published == 'true'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const publishedPackages = ${{ steps.publish-canary.outputs.publishedPackages }};
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                `> [!NOTE]`,
+                `> The following canaries were published to NPM:`,
+                `>`,
+                ...publishedPackages.map((pkg) => `> - [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`),
+                '',
+                '🐥'
+              ].join('\n')
+            });
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: '🐥 Canaries',
+            });
+  CD:
+    name: Manage main-branch release
+    # only run if CI is successful
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "package-lock.json"
 
-      # See https://docs.npmjs.com/trusted-publishers
-      # Find the latest version with `npm info npm@latest version`
-      - name: Install suitable NPM version for trusted publishing
-        run: npm install -g npm@11.10.1
+      - uses: ./.github/actions/setup-node-and-npm-for-publishing
 
       - name: Install
         run: npm ci


### PR DESCRIPTION
Attempting to add a canary release workflow, modelled after [the one in CSNX](https://github.com/guardian/csnx/blob/main/.github/workflows/npm-publish.yml)

We believe that there has to be only one workflow for both types of publishing, given that we're using NPM trusted publishing.

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->