### PR TITLE
Remove workflow_dispatch trigger from workflow

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -10,7 +10,6 @@ on:
     workflows: [CI]
     branches: [main]
     types: [completed]
-  workflow_dispatch: # Allow manual triggering of the workflow
 
 permissions:
   contents: write
@@ -19,7 +18,7 @@ permissions:
 
 jobs:
   release-canaries:
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, '🐥 Canaries')) || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, '🐥 Canaries') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
We added the `workflow_dispatch` trigger for testing purposes in #70 but it shouldn't be needed anymore. Workflow can be triggered by adding the label.

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->