### PR TITLE
Remove string interpolation into script

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const publishedPackages = ${{ steps.publish-canary.outputs.publishedPackages }};
+            const publishedPackages = JSON.parse(process.env.PUBLISHED_PACKAGES);
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -81,6 +81,8 @@ jobs:
               issue_number: context.issue.number,
               name: '🐥 Canaries',
             });
+        env:
+          PUBLISHED_PACKAGES: ${{ toJSON(steps.publish-canary.outputs.publishedPackages) }}
   CD:
     name: Manage main-branch release
     # only run if CI is successful

--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -82,7 +82,7 @@ jobs:
               name: '🐥 Canaries',
             });
         env:
-          PUBLISHED_PACKAGES: ${{ toJSON(steps.publish-canary.outputs.publishedPackages) }}
+          PUBLISHED_PACKAGES: ${{ steps.publish-canary.outputs.publishedPackages }}
   CD:
     name: Manage main-branch release
     # only run if CI is successful


### PR DESCRIPTION
Including published package info via interpolation into the script leaves it open to injection of malicious code. The output of the `publish-canary` step *should* be safe to trust, but it feels reasonable to try and avoid having to trust it.