### PR TITLE
Replace `iniparser` dependency with better-maintained `ini` package

### DIFF
--- a/.changeset/large-foxes-destroy.md
+++ b/.changeset/large-foxes-destroy.md
@@ -2,4 +2,4 @@
 "@guardian/pan-domain-node": patch
 ---
 
-Replaces inparser dependency with ini.
+Replaces iniparser dependency with ini.

--- a/.changeset/large-foxes-destroy.md
+++ b/.changeset/large-foxes-destroy.md
@@ -1,0 +1,5 @@
+---
+"@guardian/pan-domain-node": patch
+---
+
+Replaces inparser dependency with ini.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,19 +1,14 @@
 module.exports = {
-  "roots": [
-    "<rootDir>/src",
-    "<rootDir>/test"
-  ],
-  "clearMocks": true,
-  "transform": {
-    "^.+\\.tsx?$": "ts-jest"
+  globals: {
+    "ts-jest": {
+      tsconfig: "test/tsconfig.json",
+    },
   },
-  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
-  "moduleFileExtensions": [
-    "ts",
-    "tsx",
-    "js",
-    "jsx",
-    "json",
-    "node"
-  ],
-}
+  roots: ["<rootDir>/src", "<rootDir>/test"],
+  clearMocks: true,
+  transform: {
+    "^.+\\.tsx?$": "ts-jest",
+  },
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@aws-sdk/client-s3": "^3.1061.0",
         "@aws-sdk/credential-providers": "^3.1061.0",
         "cookie": "^0.4.1",
-        "iniparser": "^1.0.5"
+        "ini": "6.0.0"
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.973.10",
         "@changesets/cli": "^2.27.10",
         "@types/cookie": "^0.4.0",
-        "@types/iniparser": "0.0.29",
+        "@types/ini": "^4.1.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.1",
         "jest": "^29.7.0",
@@ -2206,11 +2206,12 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/iniparser": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/iniparser/-/iniparser-0.0.29.tgz",
-      "integrity": "sha1-i9BboJXgpTFQ4xVPoCjGo+U4p18=",
-      "dev": true
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -3473,12 +3474,13 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/iniparser": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/iniparser/-/iniparser-1.0.5.tgz",
-      "integrity": "sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=",
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
       "engines": {
-        "node": "*"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/is-arrayish": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/types": "^3.973.10",
     "@changesets/cli": "^2.27.10",
     "@types/cookie": "^0.4.0",
-    "@types/iniparser": "0.0.29",
+    "@types/ini": "4.1.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.1",
     "jest": "^29.7.0",
@@ -36,7 +36,7 @@
     "@aws-sdk/client-s3": "^3.1061.0",
     "@aws-sdk/credential-providers": "^3.1061.0",
     "cookie": "^0.4.1",
-    "iniparser": "^1.0.5"
+    "ini": "6.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/src/fetch-public-key.ts
+++ b/src/fetch-public-key.ts
@@ -1,43 +1,50 @@
-import * as iniparser from 'iniparser';
-import {base64ToPEM, httpGet} from './utils';
 import { S3 } from "@aws-sdk/client-s3";
+import * as iniparser from "iniparser";
+import { base64ToPEM } from "./utils";
 
 export interface PublicKeyHolder {
-    key: string,
-    lastUpdated: Date
+  key: string;
+  lastUpdated: Date;
 }
 
+export function fetchPublicKey(
+  s3: S3,
+  bucket: string,
+  keyFile: string,
+): Promise<PublicKeyHolder> {
+  const publicKeyLocation = {
+    Bucket: bucket,
+    Key: keyFile,
+  };
 
-export function fetchPublicKey(s3: S3, bucket: string, keyFile: string): Promise<PublicKeyHolder> {
+  return s3
+    .getObject(publicKeyLocation)
+    .then(({ Body }) => Body?.transformToString())
+    .then((maybePandaConfigIni) => {
+      if (!maybePandaConfigIni) {
+        throw Error(
+          `could not read panda config ${JSON.stringify(publicKeyLocation)}`,
+        );
+      }
+      return parseKeysFromIni(maybePandaConfigIni);
+    })
+    .catch((error) => {
+      console.error(`Error fetching public key from S3: ${error}`);
+      throw error;
+    });
+}
 
-    const publicKeyLocation = {
-        Bucket: bucket,
-        Key: keyFile,
+export function parseKeysFromIni(pandaConfigIni: string): PublicKeyHolder {
+  const config: { publicKey?: string } = iniparser.parseString(pandaConfigIni);
+  if (config.publicKey) {
+    return {
+      key: base64ToPEM(config.publicKey, "PUBLIC"),
+      lastUpdated: new Date(),
     };
-
-    return s3.getObject(publicKeyLocation)
-        .then(({ Body }) => Body?.transformToString())
-        .then((pandaConfigIni) => {
-            if (!pandaConfigIni) {
-                throw Error(`could not read panda config ${JSON.stringify(publicKeyLocation)}`);
-            }
-            else {
-                const config: { publicKey?: string } = iniparser.parseString(pandaConfigIni);
-                if (config.publicKey) {
-                    return {
-                        key: base64ToPEM(config.publicKey, "PUBLIC"),
-                        lastUpdated: new Date()
-                    };
-                } else {
-                    console.log(`Failed to retrieve panda public key from ${JSON.stringify(config)}`);
-                    throw new Error("Missing publicKey setting from config");
-                }
-            }
-        })
-        .catch((error) => {
-            console.error(`Error fetching public key from S3: ${error}`);
-            throw error;
-        });
+  } else {
+    console.log(
+      `Failed to retrieve panda public key from ${JSON.stringify(config)}`,
+    );
+    throw new Error("Missing publicKey setting from config");
+  }
 }
-
-

--- a/src/fetch-public-key.ts
+++ b/src/fetch-public-key.ts
@@ -1,5 +1,5 @@
 import { S3 } from "@aws-sdk/client-s3";
-import * as iniparser from "iniparser";
+import * as ini from "ini";
 import { base64ToPEM } from "./utils";
 
 export interface PublicKeyHolder {
@@ -35,7 +35,7 @@ export function fetchPublicKey(
 }
 
 export function parseKeysFromIni(pandaConfigIni: string): PublicKeyHolder {
-  const config: { publicKey?: string } = iniparser.parseString(pandaConfigIni);
+  const config: Record<string, string> = ini.parse(pandaConfigIni);
   if (config.publicKey) {
     return {
       key: base64ToPEM(config.publicKey, "PUBLIC"),

--- a/test/fetch-public-keys.test.ts
+++ b/test/fetch-public-keys.test.ts
@@ -1,0 +1,35 @@
+import { parseKeysFromIni } from "../src/fetch-public-key";
+
+describe("parseKeysFromIni", () => {
+  it("should parse a valid ini string and return the public key", () => {
+    const iniString = [
+      "aValue=someValue",
+      "publicKey=abcd123==",
+      "someOtherKey=someValue",
+    ].join("\n");
+
+    const result = parseKeysFromIni(iniString);
+    expect(result).toHaveProperty("key");
+    expect(result.key).toBe(
+      "-----BEGIN PUBLIC KEY-----\nabcd123==\n-----END PUBLIC KEY-----",
+    );
+    expect(result).toHaveProperty("lastUpdated");
+    expect(result.lastUpdated).toBeInstanceOf(Date);
+  });
+
+  it("should throw an error if the publicKey is missing", () => {
+    const iniString = "someOtherKey=someValue";
+
+    expect(() => parseKeysFromIni(iniString)).toThrow(
+      "Missing publicKey setting from config",
+    );
+  });
+
+  it("should throw an error if the ini string is empty", () => {
+    const iniString = "";
+
+    expect(() => parseKeysFromIni(iniString)).toThrow(
+      "Missing publicKey setting from config",
+    );
+  });
+});

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -431,7 +431,7 @@ describe("panda class", function () {
       const panda = createDefaultPandaWith({
         validateUser: guardianValidation,
       });
-      // The cookie headers should be semicolon-separated name=valueg
+      // The cookie headers should be semicolon-separated name=value
       const authenticationResult = await panda.verify(sampleNonGuardianCookie);
 
       const expected: CookieFailure = {

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -29,7 +29,6 @@ import {
 } from "./fixtures";
 
 jest.mock("../src/fetch-public-key");
-jest.useFakeTimers();
 
 function userFromCookie(cookie: string): User {
   // This function is only used to generate a `User` object from
@@ -38,6 +37,32 @@ function userFromCookie(cookie: string): User {
   // to have to deal with the case of a bad cookie so we just cast to `ParsedCookie`.
   const parsedCookie = parseCookie(cookie) as ParsedCookie;
   return parseUser(parsedCookie.data);
+}
+
+function createDefaultPandaWith(
+  overrides: Partial<{
+    cookieName: string;
+    region: string;
+    bucket: string;
+    keyFile: string;
+    validateUser: typeof guardianValidation;
+  }> = {},
+): PanDomainAuthentication {
+  const defaultParams = {
+    cookieName: "cookiename",
+    region: "region",
+    bucket: "bucket",
+    keyFile: "keyfile",
+    validateUser: () => true,
+  };
+  const finalParams = { ...defaultParams, ...overrides };
+  return new PanDomainAuthentication(
+    finalParams.cookieName,
+    finalParams.region,
+    finalParams.bucket,
+    finalParams.keyFile,
+    finalParams.validateUser,
+  );
 }
 
 describe("verifyUser", function () {
@@ -224,20 +249,20 @@ describe("createCookie", function () {
 
 describe("panda class", function () {
   beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
     (
       fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
     ).mockResolvedValue({ key: "PUBLIC KEY", lastUpdated: new Date() });
   });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
 
   describe("stop", () => {
-    it("stops auto refresh", () => {
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        (u) => true,
-      );
+    it("stops auto refresh", async () => {
+      const panda = createDefaultPandaWith();
       expect(panda.keyUpdateTimer).not.toBeUndefined();
       panda.stop();
       expect(panda.keyUpdateTimer).toBeUndefined();
@@ -246,13 +271,7 @@ describe("panda class", function () {
 
   describe("getPublicKey", () => {
     it("getsPublicKey immediately when last fetch is within the cache time", async () => {
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        (u) => true,
-      );
+      const panda = createDefaultPandaWith();
       const fetchesBeforeGet = (
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
       ).mock.calls.length;
@@ -274,13 +293,7 @@ describe("panda class", function () {
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
       ).mockResolvedValue({ key: "PUBLIC KEY", lastUpdated: fiveMinsAgo });
 
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        (u) => true,
-      );
+      const panda = createDefaultPandaWith();
 
       const fetchesBefore = (
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
@@ -311,13 +324,7 @@ describe("panda class", function () {
 
     it("should authenticate if cookie and user are valid", async () => {
       jest.setSystemTime(100);
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        (u) => true,
-      );
+      const panda = createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `cookiename=${sampleCookie}`,
       );
@@ -333,13 +340,7 @@ describe("panda class", function () {
 
     it("should authenticate if cookie and user are valid when multiple cookies are passed", async () => {
       jest.setSystemTime(100);
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        (u) => true,
-      );
+      const panda = createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `a=blah; b=stuff; cookiename=${sampleCookie}; c=4958345`,
       );
@@ -358,13 +359,7 @@ describe("panda class", function () {
       const afterEndOfGracePeriodEpochMillis = 1234 + gracePeriodInMillis + 1;
       jest.setSystemTime(afterEndOfGracePeriodEpochMillis);
 
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        (u) => true,
-      );
+      const panda = createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `cookiename=${sampleCookie}`,
       );
@@ -381,13 +376,7 @@ describe("panda class", function () {
       const beforeEndOfGracePeriodEpochMillis = 1234 + gracePeriodInMillis - 1;
       jest.setSystemTime(beforeEndOfGracePeriodEpochMillis);
 
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        (u) => true,
-      );
+      const panda = createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `cookiename=${sampleCookie}`,
       );
@@ -404,13 +393,9 @@ describe("panda class", function () {
     it("should fail to authenticate if user is not valid", async () => {
       jest.setSystemTime(100);
 
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        guardianValidation,
-      );
+      const panda = createDefaultPandaWith({
+        validateUser: guardianValidation,
+      });
       const authenticationResult = await panda.verify(
         `cookiename=${sampleNonGuardianCookie}`,
       );
@@ -426,13 +411,9 @@ describe("panda class", function () {
     it("should fail to authenticate if there is no cookie with the correct name", async () => {
       jest.setSystemTime(100);
 
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        guardianValidation,
-      );
+      const panda = createDefaultPandaWith({
+        validateUser: guardianValidation,
+      });
       const authenticationResult = await panda.verify(
         `wrongcookiename=${sampleNonGuardianCookie}`,
       );
@@ -447,13 +428,9 @@ describe("panda class", function () {
     it("should fail to authenticate if the cookie request header is malformed", async () => {
       jest.setSystemTime(100);
 
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        guardianValidation,
-      );
+      const panda = createDefaultPandaWith({
+        validateUser: guardianValidation,
+      });
       // The cookie headers should be semicolon-separated name=valueg
       const authenticationResult = await panda.verify(sampleNonGuardianCookie);
 
@@ -467,13 +444,9 @@ describe("panda class", function () {
     it("should fail to authenticate if there is no cookie with the correct name out of multiple cookies", async () => {
       jest.setSystemTime(100);
 
-      const panda = new PanDomainAuthentication(
-        "cookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        guardianValidation,
-      );
+      const panda = createDefaultPandaWith({
+        validateUser: guardianValidation,
+      });
       const authenticationResult = await panda.verify(
         `wrongcookiename=${sampleNonGuardianCookie}; anotherwrongcookiename=${sampleNonGuardianCookie}`,
       );
@@ -488,13 +461,10 @@ describe("panda class", function () {
     it("should fail to authenticate with invalid-cookie reason if cookie is malformed", async () => {
       jest.setSystemTime(100);
 
-      const panda = new PanDomainAuthentication(
-        "rightcookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        guardianValidation,
-      );
+      const panda = createDefaultPandaWith({
+        cookieName: "rightcookiename",
+        validateUser: guardianValidation,
+      });
       // There is a valid Panda cookie in here, but it's under the wrong name
       const authenticationResult = await panda.verify(
         `wrongcookiename=${sampleNonGuardianCookie}; rightcookiename=not-valid-panda-cookie`,
@@ -510,13 +480,10 @@ describe("panda class", function () {
     it("should fail to authenticate with no-cookie reason if no cookie is present at all", async () => {
       jest.setSystemTime(100);
 
-      const panda = new PanDomainAuthentication(
-        "rightcookiename",
-        "region",
-        "bucket",
-        "keyfile",
-        guardianValidation,
-      );
+      const panda = createDefaultPandaWith({
+        cookieName: "rightcookiename",
+        validateUser: guardianValidation,
+      });
       const noCookie = undefined;
       const authenticationResult = await panda.verify(noCookie);
 
@@ -525,6 +492,81 @@ describe("panda class", function () {
         reason: "no-cookie",
       };
       expect(authenticationResult).toStrictEqual(expected);
+    });
+  });
+
+  describe("refresh behaviour", () => {
+    beforeEach(() => {
+      (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mockResolvedValue({ key: publicKey, lastUpdated: new Date() });
+    });
+
+    it("should refresh the public key on a schedule", async () => {
+      const _panda = createDefaultPandaWith();
+      const fetchesBefore = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      /**
+       * Advance time by 2 minutes, which is longer than the cache time of 1 minute.
+       * advanceTimersByTimeAsync also flushes async timer callbacks (e.g. the async setInterval).
+       */
+      await jest.advanceTimersByTimeAsync(2 * 60 * 1000);
+
+      const fetchesAfter = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      expect(fetchesAfter).toBeGreaterThan(fetchesBefore);
+    });
+
+    it("should refresh the public key when 'verify' is called after the cache time has elapsed", async () => {
+      const panda = createDefaultPandaWith({
+        validateUser: guardianValidation,
+      });
+      panda.stop(); // Stop the auto-refresh so we can control when the refresh happens
+      const fetchesBefore = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      /**
+       * Advance time by 2 minutes, which is longer than the cache time of 1 minute.
+       * advanceTimersByTimeAsync also flushes async timer callbacks (e.g. the async setInterval).
+       */
+      await jest.advanceTimersByTimeAsync(2 * 60 * 1000);
+
+      const fetchesAfterWait = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      expect(fetchesAfterWait).toEqual(fetchesBefore);
+
+      await panda.verify(`cookiename=${sampleCookie}`);
+
+      const fetchesAfter = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      expect(fetchesAfter).toBeGreaterThan(fetchesBefore);
+    });
+
+    it("should use the cached key when 'verify' is called if the cache time has not elapsed", async () => {
+      const panda = createDefaultPandaWith({
+        validateUser: guardianValidation,
+      });
+      panda.stop(); // Stop the auto-refresh so we can control when the refresh happens
+      const fetchesBefore = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      await panda.verify(`cookiename=${sampleCookie}`);
+
+      const fetchesAfter = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      expect(fetchesAfter).toEqual(fetchesBefore);
     });
   });
 });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "types": ["@types/node", "@types/jest"]
+  }
+}


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

[iniparser](https://www.npmjs.com/package/iniparser) hasn't been published for 14 years, and the repo is archived.

[ini](https://www.npmjs.com/package/ini) provides the functionality that we need, it's still being updated, and seems to be maintained [by `npm`](https://github.com/npm/ini).

Neither package has any runtime dependencies, so we aren't introducing any new transitive deps by switching.

As part of the upgrade, I extracted the ini parsing functionality in an initial commit (7c6e204) and added a couple of unit tests to document the existing behaviour, to give a bit of confidence that we're not introducing regressions.

This is a preparatory refactor in support of #28 
