### PR TITLE
Convert verification to async/await

### DIFF
--- a/src/panda.ts
+++ b/src/panda.ts
@@ -153,29 +153,26 @@ export class PanDomainAuthentication {
     }
   }
 
-  getPublicKey(): Promise<string> {
-    return this.publicKey.then(({ key, lastUpdated }) => {
-      const now = new Date();
-      const diff = now.getTime() - lastUpdated.getTime();
+  async getPublicKey(): Promise<string> {
+    const publicKeyHolder = await this.publicKey;
+    const now = new Date();
+    const diff = now.getTime() - publicKeyHolder.lastUpdated.getTime();
 
-      if (diff > this.keyCacheTimeInMillis) {
-        this.publicKey = fetchPublicKey(
-          this.s3Client,
-          this.bucket,
-          this.keyFile,
-        );
-        return this.publicKey.then(({ key }) => key);
-      } else {
-        return key;
-      }
-    });
+    if (diff > this.keyCacheTimeInMillis) {
+      this.publicKey = fetchPublicKey(this.s3Client, this.bucket, this.keyFile);
+      const { key } = await this.publicKey;
+      return key;
+    } else {
+      return publicKeyHolder.key;
+    }
   }
 
-  verify(requestCookies: string | undefined): Promise<AuthenticationResult> {
-    return this.getPublicKey().then((publicKey) => {
-      const cookies = cookie.parse(requestCookies ?? "");
-      const pandaCookie = cookies[this.cookieName];
-      return verifyUser(pandaCookie, publicKey, new Date(), this.validateUser);
-    });
+  async verify(
+    requestCookies: string | undefined,
+  ): Promise<AuthenticationResult> {
+    const publicKey = await this.getPublicKey();
+    const cookies = cookie.parse(requestCookies ?? "");
+    const pandaCookie = cookies[this.cookieName];
+    return verifyUser(pandaCookie, publicKey, new Date(), this.validateUser);
   }
 }

--- a/src/panda.ts
+++ b/src/panda.ts
@@ -1,156 +1,181 @@
-import * as cookie from 'cookie';
+import * as cookie from "cookie";
 
-import {parseCookie, parseUser, sign, verifySignature} from './utils';
-import {User, AuthenticationResult, ValidateUserFn, gracePeriodInMillis} from './api';
-import { fetchPublicKey, PublicKeyHolder } from './fetch-public-key';
 import { S3 } from "@aws-sdk/client-s3";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import {
+  AuthenticationResult,
+  gracePeriodInMillis,
+  User,
+  ValidateUserFn,
+} from "./api";
+import { fetchPublicKey, PublicKeyHolder } from "./fetch-public-key";
+import { parseCookie, parseUser, sign, verifySignature } from "./utils";
 
 export function createCookie(user: User, privateKey: string): string {
-    let queryParams: string[] = [];
+  let queryParams: string[] = [];
 
-    queryParams.push("firstName=" + user.firstName);
-    queryParams.push("lastName=" + user.lastName);
-    queryParams.push("email=" + user.email);
-    user.avatarUrl && queryParams.push("avatarUrl=" + user.avatarUrl);
-    queryParams.push("system=" + user.authenticatingSystem);
-    queryParams.push("authedIn=" + user.authenticatedIn.join(","));
-    queryParams.push("expires=" + user.expires.toString());
-    queryParams.push("multifactor=" + String(user.multifactor));
-    const combined = queryParams.join("&");
+  queryParams.push("firstName=" + user.firstName);
+  queryParams.push("lastName=" + user.lastName);
+  queryParams.push("email=" + user.email);
+  user.avatarUrl && queryParams.push("avatarUrl=" + user.avatarUrl);
+  queryParams.push("system=" + user.authenticatingSystem);
+  queryParams.push("authedIn=" + user.authenticatedIn.join(","));
+  queryParams.push("expires=" + user.expires.toString());
+  queryParams.push("multifactor=" + String(user.multifactor));
+  const combined = queryParams.join("&");
 
-    const queryParamsString = Buffer.from(combined).toString('base64');
+  const queryParamsString = Buffer.from(combined).toString("base64");
 
-    const signature = sign(combined, privateKey);
+  const signature = sign(combined, privateKey);
 
-    return queryParamsString + "." + signature
+  return queryParamsString + "." + signature;
 }
 
-export function verifyUser(pandaCookie: string | undefined, publicKey: string, currentTime: Date, validateUser: ValidateUserFn): AuthenticationResult {
-    if (!pandaCookie) {
+export function verifyUser(
+  pandaCookie: string | undefined,
+  publicKey: string,
+  currentTime: Date,
+  validateUser: ValidateUserFn,
+): AuthenticationResult {
+  if (!pandaCookie) {
+    return {
+      success: false,
+      reason: "no-cookie",
+    };
+  }
+
+  const parsedCookie = parseCookie(pandaCookie);
+  if (!parsedCookie) {
+    return {
+      success: false,
+      reason: "invalid-cookie",
+    };
+  }
+  const { data, signature } = parsedCookie;
+
+  if (!verifySignature(data, signature, publicKey)) {
+    return {
+      success: false,
+      reason: "invalid-cookie",
+    };
+  }
+
+  const currentTimestampInMillis = currentTime.getTime();
+
+  try {
+    const user: User = parseUser(data);
+    const isExpired = user.expires < currentTimestampInMillis;
+
+    if (isExpired) {
+      const gracePeriodEndsAtEpochTimeMillis =
+        user.expires + gracePeriodInMillis;
+      if (gracePeriodEndsAtEpochTimeMillis < currentTimestampInMillis) {
         return {
-            success: false,
-            reason: 'no-cookie'
+          success: false,
+          reason: "expired-cookie",
         };
+      } else {
+        return {
+          success: true,
+          shouldRefreshCredentials: true,
+          mustRefreshByEpochTimeMillis: gracePeriodEndsAtEpochTimeMillis,
+          user,
+        };
+      }
     }
 
-    const parsedCookie = parseCookie(pandaCookie);
-    if (!parsedCookie) {
-        return {
-            success: false,
-            reason: 'invalid-cookie'
-        };
-    }
-    const { data, signature } = parsedCookie;
-
-    if (!verifySignature(data, signature, publicKey)) {
-        return {
-            success: false,
-            reason: 'invalid-cookie'
-        };
+    if (!validateUser(user)) {
+      return {
+        success: false,
+        reason: "invalid-user",
+        user,
+      };
     }
 
-    const currentTimestampInMillis = currentTime.getTime();
-
-    try {
-        const user: User = parseUser(data);
-        const isExpired = user.expires < currentTimestampInMillis;
-
-        if (isExpired) {
-            const gracePeriodEndsAtEpochTimeMillis = user.expires + gracePeriodInMillis;
-            if (gracePeriodEndsAtEpochTimeMillis < currentTimestampInMillis) {
-                return {
-                    success: false,
-                    reason: 'expired-cookie'
-                };
-            } else {
-                return {
-                    success: true,
-                    shouldRefreshCredentials: true,
-                    mustRefreshByEpochTimeMillis: gracePeriodEndsAtEpochTimeMillis,
-                    user
-                }
-            }
-        }
-
-        if (!validateUser(user)) {
-            return {
-                success: false,
-                reason: 'invalid-user',
-                user
-            };
-        }
-
-        return {
-            success: true,
-            shouldRefreshCredentials: false,
-            user
-        };
-    } catch (error) {
-        console.error(error);
-        return {
-            success: false,
-            reason: 'unknown'
-        };
-    }
+    return {
+      success: true,
+      shouldRefreshCredentials: false,
+      user,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      success: false,
+      reason: "unknown",
+    };
+  }
 }
 
 export class PanDomainAuthentication {
-    cookieName: string;
-    region: string;
-    bucket: string;
-    keyFile: string;
-    validateUser: ValidateUserFn;
+  cookieName: string;
+  region: string;
+  bucket: string;
+  keyFile: string;
+  validateUser: ValidateUserFn;
 
-    publicKey: Promise<PublicKeyHolder>;
-    keyCacheTimeInMillis: number = 60 * 1000; // 1 minute
-    keyUpdateTimer?: NodeJS.Timeout;
-    s3Client: S3;
+  publicKey: Promise<PublicKeyHolder>;
+  keyCacheTimeInMillis: number = 60 * 1000; // 1 minute
+  keyUpdateTimer?: NodeJS.Timeout;
+  s3Client: S3;
 
-    constructor(cookieName: string, region: string, bucket: string, keyFile: string, validateUser: ValidateUserFn, credentialsProvider: AwsCredentialIdentityProvider = fromNodeProviderChain()) {
-        this.cookieName = cookieName;
-        this.region = region;
-        this.bucket = bucket;
-        this.keyFile = keyFile;
-        this.validateUser = validateUser;
+  constructor(
+    cookieName: string,
+    region: string,
+    bucket: string,
+    keyFile: string,
+    validateUser: ValidateUserFn,
+    credentialsProvider: AwsCredentialIdentityProvider = fromNodeProviderChain(),
+  ) {
+    this.cookieName = cookieName;
+    this.region = region;
+    this.bucket = bucket;
+    this.keyFile = keyFile;
+    this.validateUser = validateUser;
 
-        const standardAwsConfig = {
-            region: region,
-            credentials: credentialsProvider,
-        }; 
-        this.s3Client = new S3(standardAwsConfig);
-        this.publicKey = fetchPublicKey(this.s3Client, bucket, keyFile);
+    const standardAwsConfig = {
+      region: region,
+      credentials: credentialsProvider,
+    };
+    this.s3Client = new S3(standardAwsConfig);
+    this.publicKey = fetchPublicKey(this.s3Client, bucket, keyFile);
 
-        this.keyUpdateTimer = setInterval(() => this.getPublicKey(), this.keyCacheTimeInMillis);
+    this.keyUpdateTimer = setInterval(
+      () => this.getPublicKey(),
+      this.keyCacheTimeInMillis,
+    );
+  }
+
+  stop(): void {
+    if (this.keyUpdateTimer) {
+      clearInterval(this.keyUpdateTimer);
+      this.keyUpdateTimer = undefined;
     }
+  }
 
-    stop(): void {
-        if(this.keyUpdateTimer) {
-            clearInterval(this.keyUpdateTimer);
-            this.keyUpdateTimer = undefined;
-        }
-    }
+  getPublicKey(): Promise<string> {
+    return this.publicKey.then(({ key, lastUpdated }) => {
+      const now = new Date();
+      const diff = now.getTime() - lastUpdated.getTime();
 
-    getPublicKey(): Promise<string> {
-        return this.publicKey.then(({ key, lastUpdated }) => {
-            const now = new Date();
-            const diff = now.getTime() - lastUpdated.getTime();
+      if (diff > this.keyCacheTimeInMillis) {
+        this.publicKey = fetchPublicKey(
+          this.s3Client,
+          this.bucket,
+          this.keyFile,
+        );
+        return this.publicKey.then(({ key }) => key);
+      } else {
+        return key;
+      }
+    });
+  }
 
-            if(diff > this.keyCacheTimeInMillis) {
-                this.publicKey = fetchPublicKey(this.s3Client, this.bucket, this.keyFile);
-                return this.publicKey.then(({ key }) => key);
-            } else {
-                return key;
-            }
-        });
-    }
-
-    verify(requestCookies: string | undefined): Promise<AuthenticationResult> {
-        return this.getPublicKey().then(publicKey => {
-            const cookies = cookie.parse(requestCookies ?? '');
-            const pandaCookie = cookies[this.cookieName];
-            return verifyUser(pandaCookie, publicKey, new Date(), this.validateUser);
-        });
-    }
+  verify(requestCookies: string | undefined): Promise<AuthenticationResult> {
+    return this.getPublicKey().then((publicKey) => {
+      const cookies = cookie.parse(requestCookies ?? "");
+      const pandaCookie = cookies[this.cookieName];
+      return verifyUser(pandaCookie, publicKey, new Date(), this.validateUser);
+    });
+  }
 }


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

Refactor the verification and key fetching logic in `panda.ts` from using chained `.then()` callbacks, to using async/await. I think this makes the flow of logic easier to understand when reading the code.

I've formatted `panda.ts` using Prettier, so the diff is fairly large. However, the formatting is done in a separate commit, so to review just the substantive changes you can look at 2e144558b3206c9bc99eb4f56ad3129eb1aba128

---
Introduced as a preparatory refactor to support [#28 Support smooth key-rotation, accept multiple public-keys](https://github.com/guardian/pan-domain-node/issues/28). Follows #75 