### PR TITLE
Validate user before checking for grace period

### DIFF
--- a/src/panda.ts
+++ b/src/panda.ts
@@ -67,6 +67,14 @@ export function verifyUser(
     const user: User = parseUser(data);
     const isExpired = user.expires < currentTimestampInMillis;
 
+    if (!validateUser(user)) {
+      return {
+        success: false,
+        reason: "invalid-user",
+        user,
+      };
+    }
+
     if (isExpired) {
       const gracePeriodEndsAtEpochTimeMillis =
         user.expires + gracePeriodInMillis;
@@ -83,14 +91,6 @@ export function verifyUser(
           user,
         };
       }
-    }
-
-    if (!validateUser(user)) {
-      return {
-        success: false,
-        reason: "invalid-user",
-        user,
-      };
     }
 
     return {


### PR DESCRIPTION
A CoPilot review of a different PR raised the point that the grace period check branch might return early and verify a user whose cookie was expired but within the grace period, before we'd validated their status: https://github.com/guardian/pan-domain-node/pull/76#discussion_r3516070557

Having looked at it, I think CoPilot is right that this is undesirable behaviour, so this branch moves the `validateUser` check above the grace period check.

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->