### PR TITLE
Change instantiation to use async builder method

### DIFF
--- a/.changeset/moody-items-drum.md
+++ b/.changeset/moody-items-drum.md
@@ -1,0 +1,13 @@
+---
+"@guardian/pan-domain-node": major
+---
+
+Create async builder method to instantiate PanDomainAuthentication class
+
+Before: `const panda = new PanDomainAuthentication(...)`
+
+After: `const panda = await PanDomainAuthentication.builder(...)`
+
+This is a breaking change in how the main class is instantiated, allowing for better control flow in the way we handle fetching and updating public keys.
+
+After instantiation, the usage of the class is the same as before.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@aws-sdk/types": "^3.973.10",
         "@changesets/cli": "^2.27.10",
         "@types/cookie": "^0.4.0",
-        "@types/ini": "^4.1.1",
+        "@types/ini": "4.1.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.1",
         "jest": "^29.7.0",

--- a/src/fetch-public-key.ts
+++ b/src/fetch-public-key.ts
@@ -7,11 +7,15 @@ export interface PublicKeyHolder {
   lastUpdated: Date;
 }
 
-export function fetchPublicKey(
-  s3: S3,
-  bucket: string,
-  keyFile: string,
-): Promise<PublicKeyHolder> {
+export function fetchPublicKey({
+  s3,
+  bucket,
+  keyFile,
+}: {
+  s3: S3;
+  bucket: string;
+  keyFile: string;
+}): Promise<PublicKeyHolder> {
   const publicKeyLocation = {
     Bucket: bucket,
     Key: keyFile,

--- a/src/getErrorMessage.ts
+++ b/src/getErrorMessage.ts
@@ -1,0 +1,39 @@
+/**
+ * Cribbed from https://github.com/guardian/csnx/blob/main/libs/%40guardian/libs/src/getErrorMessage/getErrorMessage.ts
+ * It would be better to install the @guardian/libs package and import it from there,
+ * but we'd need to upgrade TypeScript and some other stuff in this project first.
+ */
+
+type ErrorWithMessage = {
+  message: string;
+};
+
+function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as Record<string, unknown>).message === "string"
+  );
+}
+
+function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
+  if (isErrorWithMessage(maybeError)) {
+    return maybeError;
+  }
+
+  try {
+    if (typeof maybeError === "string") {
+      return new Error(maybeError);
+    }
+    return new Error(JSON.stringify(maybeError));
+  } catch {
+    // fallback in case there's an error stringifying the maybeError
+    // like with circular references for example.
+    return new Error(String(maybeError));
+  }
+}
+
+export function getErrorMessage(error: unknown): string {
+  return toErrorWithMessage(error).message;
+}

--- a/src/panda.ts
+++ b/src/panda.ts
@@ -10,6 +10,7 @@ import {
   ValidateUserFn,
 } from "./api";
 import { fetchPublicKey, PublicKeyHolder } from "./fetch-public-key";
+import { getErrorMessage } from "./getErrorMessage";
 import { parseCookie, parseUser, sign, verifySignature } from "./utils";
 
 export function createCookie(user: User, privateKey: string): string {
@@ -107,38 +108,68 @@ export function verifyUser(
   }
 }
 
-export class PanDomainAuthentication {
+export type BuilderParams = {
   cookieName: string;
   region: string;
   bucket: string;
   keyFile: string;
   validateUser: ValidateUserFn;
+  credentialsProvider?: AwsCredentialIdentityProvider;
+};
 
-  publicKey: Promise<PublicKeyHolder>;
+export class PanDomainAuthentication {
+  cookieName: string;
+  bucket: string;
+  keyFile: string;
+  validateUser: ValidateUserFn;
+
+  publicKey: PublicKeyHolder;
   keyCacheTimeInMillis: number = 60 * 1000; // 1 minute
   keyUpdateTimer?: NodeJS.Timeout;
   s3Client: S3;
 
+  static async builder({
+    cookieName,
+    region,
+    bucket,
+    keyFile,
+    validateUser,
+    credentialsProvider = fromNodeProviderChain(),
+  }: BuilderParams): Promise<PanDomainAuthentication> {
+    const s3Client = new S3({
+      region,
+      credentials: credentialsProvider,
+    });
+    const publicKey = await fetchPublicKey({
+      s3: s3Client,
+      bucket,
+      keyFile,
+    });
+
+    return new PanDomainAuthentication(
+      cookieName,
+      bucket,
+      s3Client,
+      keyFile,
+      validateUser,
+      publicKey,
+    );
+  }
+
   constructor(
     cookieName: string,
-    region: string,
     bucket: string,
+    s3Client: S3,
     keyFile: string,
     validateUser: ValidateUserFn,
-    credentialsProvider: AwsCredentialIdentityProvider = fromNodeProviderChain(),
+    publicKey: PublicKeyHolder,
   ) {
     this.cookieName = cookieName;
-    this.region = region;
     this.bucket = bucket;
     this.keyFile = keyFile;
+    this.publicKey = publicKey;
     this.validateUser = validateUser;
-
-    const standardAwsConfig = {
-      region: region,
-      credentials: credentialsProvider,
-    };
-    this.s3Client = new S3(standardAwsConfig);
-    this.publicKey = fetchPublicKey(this.s3Client, bucket, keyFile);
+    this.s3Client = s3Client;
 
     this.keyUpdateTimer = setInterval(
       () => this.getPublicKey(),
@@ -150,18 +181,34 @@ export class PanDomainAuthentication {
     if (this.keyUpdateTimer) {
       clearInterval(this.keyUpdateTimer);
       this.keyUpdateTimer = undefined;
+      console.log("Stopped key update timer for PanDomainAuthentication");
     }
   }
 
   async getPublicKey(): Promise<string> {
-    const publicKeyHolder = await this.publicKey;
+    const publicKeyHolder = this.publicKey;
     const now = new Date();
     const diff = now.getTime() - publicKeyHolder.lastUpdated.getTime();
 
     if (diff > this.keyCacheTimeInMillis) {
-      this.publicKey = fetchPublicKey(this.s3Client, this.bucket, this.keyFile);
-      const { key } = await this.publicKey;
-      return key;
+      try {
+        const newKeyHolder = await fetchPublicKey({
+          s3: this.s3Client,
+          bucket: this.bucket,
+          keyFile: this.keyFile,
+        });
+        const { key } = newKeyHolder;
+        this.publicKey = newKeyHolder;
+
+        return key;
+      } catch (error) {
+        console.error(
+          `Error fetching public key from S3, falling back to cached key. Error: ${getErrorMessage(
+            error,
+          )}`,
+        );
+        return publicKeyHolder.key;
+      }
     } else {
       return publicKeyHolder.key;
     }

--- a/test/panda.test.ts
+++ b/test/panda.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/api";
 import { fetchPublicKey } from "../src/fetch-public-key";
 import {
+  BuilderParams,
   createCookie,
   PanDomainAuthentication,
   verifyUser,
@@ -39,30 +40,20 @@ function userFromCookie(cookie: string): User {
   return parseUser(parsedCookie.data);
 }
 
-function createDefaultPandaWith(
-  overrides: Partial<{
-    cookieName: string;
-    region: string;
-    bucket: string;
-    keyFile: string;
-    validateUser: typeof guardianValidation;
-  }> = {},
-): PanDomainAuthentication {
-  const defaultParams = {
+async function createDefaultPandaWith(
+  overrides: Partial<BuilderParams> = {},
+): Promise<PanDomainAuthentication> {
+  const defaultParams: BuilderParams = {
     cookieName: "cookiename",
     region: "region",
     bucket: "bucket",
     keyFile: "keyfile",
     validateUser: () => true,
   };
-  const finalParams = { ...defaultParams, ...overrides };
-  return new PanDomainAuthentication(
-    finalParams.cookieName,
-    finalParams.region,
-    finalParams.bucket,
-    finalParams.keyFile,
-    finalParams.validateUser,
-  );
+  return await PanDomainAuthentication.builder({
+    ...defaultParams,
+    ...overrides,
+  });
 }
 
 describe("verifyUser", function () {
@@ -249,8 +240,8 @@ describe("createCookie", function () {
 
 describe("panda class", function () {
   beforeEach(() => {
-    jest.useFakeTimers();
     jest.clearAllMocks();
+    jest.useFakeTimers();
     (
       fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
     ).mockResolvedValue({ key: "PUBLIC KEY", lastUpdated: new Date() });
@@ -262,7 +253,7 @@ describe("panda class", function () {
 
   describe("stop", () => {
     it("stops auto refresh", async () => {
-      const panda = createDefaultPandaWith();
+      const panda = await createDefaultPandaWith();
       expect(panda.keyUpdateTimer).not.toBeUndefined();
       panda.stop();
       expect(panda.keyUpdateTimer).toBeUndefined();
@@ -271,7 +262,7 @@ describe("panda class", function () {
 
   describe("getPublicKey", () => {
     it("getsPublicKey immediately when last fetch is within the cache time", async () => {
-      const panda = createDefaultPandaWith();
+      const panda = await createDefaultPandaWith();
       const fetchesBeforeGet = (
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
       ).mock.calls.length;
@@ -293,7 +284,7 @@ describe("panda class", function () {
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
       ).mockResolvedValue({ key: "PUBLIC KEY", lastUpdated: fiveMinsAgo });
 
-      const panda = createDefaultPandaWith();
+      const panda = await createDefaultPandaWith();
 
       const fetchesBefore = (
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
@@ -313,6 +304,44 @@ describe("panda class", function () {
 
       expect(fetchesAfter).toEqual(fetchesBefore + 1);
     });
+
+    it("throws if fetchPublicKey fails as part of initialisation via builder method", async () => {
+      (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mockRejectedValue(new Error("Failed to fetch public key"));
+
+      await expect(createDefaultPandaWith()).rejects.toThrow(
+        "Failed to fetch public key",
+      );
+    });
+
+    it("recovers and retains the cached key if fetchPublicKey fails after initialisation", async () => {
+      // cache time is 1 min
+      const fiveMinsAgo = new Date();
+      fiveMinsAgo.setMinutes(fiveMinsAgo.getMinutes() - 5);
+
+      (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mockResolvedValue({ key: "PUBLIC KEY", lastUpdated: fiveMinsAgo });
+
+      const panda = await createDefaultPandaWith();
+
+      const fetchesBefore = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mockRejectedValue(new Error("Failed to fetch public key"));
+
+      await expect(panda.getPublicKey()).resolves.toEqual("PUBLIC KEY");
+
+      const fetchesAfter = (
+        fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
+      ).mock.calls.length;
+
+      expect(fetchesAfter).toEqual(fetchesBefore + 1);
+    });
   });
 
   describe("verify", () => {
@@ -324,7 +353,7 @@ describe("panda class", function () {
 
     it("should authenticate if cookie and user are valid", async () => {
       jest.setSystemTime(100);
-      const panda = createDefaultPandaWith();
+      const panda = await createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `cookiename=${sampleCookie}`,
       );
@@ -340,7 +369,7 @@ describe("panda class", function () {
 
     it("should authenticate if cookie and user are valid when multiple cookies are passed", async () => {
       jest.setSystemTime(100);
-      const panda = createDefaultPandaWith();
+      const panda = await createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `a=blah; b=stuff; cookiename=${sampleCookie}; c=4958345`,
       );
@@ -359,7 +388,7 @@ describe("panda class", function () {
       const afterEndOfGracePeriodEpochMillis = 1234 + gracePeriodInMillis + 1;
       jest.setSystemTime(afterEndOfGracePeriodEpochMillis);
 
-      const panda = createDefaultPandaWith();
+      const panda = await createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `cookiename=${sampleCookie}`,
       );
@@ -376,7 +405,7 @@ describe("panda class", function () {
       const beforeEndOfGracePeriodEpochMillis = 1234 + gracePeriodInMillis - 1;
       jest.setSystemTime(beforeEndOfGracePeriodEpochMillis);
 
-      const panda = createDefaultPandaWith();
+      const panda = await createDefaultPandaWith();
       const authenticationResult = await panda.verify(
         `cookiename=${sampleCookie}`,
       );
@@ -393,7 +422,7 @@ describe("panda class", function () {
     it("should fail to authenticate if user is not valid", async () => {
       jest.setSystemTime(100);
 
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         validateUser: guardianValidation,
       });
       const authenticationResult = await panda.verify(
@@ -411,7 +440,7 @@ describe("panda class", function () {
     it("should fail to authenticate if there is no cookie with the correct name", async () => {
       jest.setSystemTime(100);
 
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         validateUser: guardianValidation,
       });
       const authenticationResult = await panda.verify(
@@ -428,7 +457,7 @@ describe("panda class", function () {
     it("should fail to authenticate if the cookie request header is malformed", async () => {
       jest.setSystemTime(100);
 
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         validateUser: guardianValidation,
       });
       // The cookie headers should be semicolon-separated name=value
@@ -444,7 +473,7 @@ describe("panda class", function () {
     it("should fail to authenticate if there is no cookie with the correct name out of multiple cookies", async () => {
       jest.setSystemTime(100);
 
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         validateUser: guardianValidation,
       });
       const authenticationResult = await panda.verify(
@@ -461,7 +490,7 @@ describe("panda class", function () {
     it("should fail to authenticate with invalid-cookie reason if cookie is malformed", async () => {
       jest.setSystemTime(100);
 
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         cookieName: "rightcookiename",
         validateUser: guardianValidation,
       });
@@ -480,7 +509,7 @@ describe("panda class", function () {
     it("should fail to authenticate with no-cookie reason if no cookie is present at all", async () => {
       jest.setSystemTime(100);
 
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         cookieName: "rightcookiename",
         validateUser: guardianValidation,
       });
@@ -503,7 +532,8 @@ describe("panda class", function () {
     });
 
     it("should refresh the public key on a schedule", async () => {
-      const _panda = createDefaultPandaWith();
+      const _panda = await createDefaultPandaWith();
+
       const fetchesBefore = (
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
       ).mock.calls.length;
@@ -522,10 +552,12 @@ describe("panda class", function () {
     });
 
     it("should refresh the public key when 'verify' is called after the cache time has elapsed", async () => {
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         validateUser: guardianValidation,
       });
+
       panda.stop(); // Stop the auto-refresh so we can control when the refresh happens
+
       const fetchesBefore = (
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
       ).mock.calls.length;
@@ -552,10 +584,12 @@ describe("panda class", function () {
     });
 
     it("should use the cached key when 'verify' is called if the cache time has not elapsed", async () => {
-      const panda = createDefaultPandaWith({
+      const panda = await createDefaultPandaWith({
         validateUser: guardianValidation,
       });
+
       panda.stop(); // Stop the auto-refresh so we can control when the refresh happens
+
       const fetchesBefore = (
         fetchPublicKey as jest.MockedFunction<typeof fetchPublicKey>
       ).mock.calls.length;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,12 @@
       "es6"
     ] /* Specify library files to be included in the compilation. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "rootDir": "./",
     "outDir": "dist" /* Redirect output structure to the directory. */,
     "strict": true /* Enable all strict type-checking options. */,
     "moduleResolution": "node16" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "types": ["@types/node"]
-  }
+  },
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "node16",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es6"],                           /* Specify library files to be included in the compilation. */
-    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
-    "outDir": "dist",                         /* Redirect output structure to the directory. */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    "moduleResolution": "node16",             /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "node16" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "es6"
+    ] /* Specify library files to be included in the compilation. */,
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "outDir": "dist" /* Redirect output structure to the directory. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "moduleResolution": "node16" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "types": ["@types/node"]
   }
 }


### PR DESCRIPTION
Adding an async `builder()` method to the `PanDomainAuthentication` class means that we can fail early if it's not possible to fetch the key on initialisation, like the Scala version of the library does.

It also means that we can store the public key as a resolved value, rather than a Promise. This in turn makes it easier to fix a bug in previous implementation, whereby a single failed fetch for the new key would mean we stored a rejected promise in this.publicKey which would never be refreshed. Now, we check whether the fetch succeeds before storing the new key. This also matches the current behaviour of the Scala library.

This introduces a **real breaking change**, because instantiation of the class will need to go from something like `const panda = new PanDomainAuthentication(...)` to `const panda = await PanDomainAuthentication.builder(...)`. My feeling is that this is a worthwhile step because it allows us to mirror the logic used in the Scala library, and makes the update logic simpler to reason about (e.g. making it easier to fix the bug mentioned above). But open to push-back on this!

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

---
Introduced as a preparatory refactor to support [#28 Support smooth key-rotation, accept multiple public-keys](https://github.com/guardian/pan-domain-node/issues/28). Follows #76 